### PR TITLE
feat: add tron GetCanWithdrawUnfreezeAmountResponse http client api

### DIFF
--- a/blockchain/tron/http_client/http_client_test.go
+++ b/blockchain/tron/http_client/http_client_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	httpclient "github.com/openweb3-io/crosschain/blockchain/tron/http_client"
@@ -74,6 +75,16 @@ func (suite *HttpClientTestSuite) TestGetAccountResource() {
 	nileTopAccount := TestNetAccountTop
 
 	resp, err := suite.client.GetAccountResource(ctx, nileTopAccount)
+	suite.Require().NoError(err)
+	suite.T().Logf("resp: %v\n", resp)
+}
+
+func (suite *HttpClientTestSuite) TestGetCanWithdrawUnfreezeAmount() {
+	ctx := context.Background()
+	nileTopAccount := TestNetAccountTop
+	timestamp := time.Now()
+
+	resp, err := suite.client.GetCanWithdrawUnfreezeAmount(ctx, nileTopAccount, timestamp)
 	suite.Require().NoError(err)
 	suite.T().Logf("resp: %v\n", resp)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to query the amount available for withdrawal and unfreeze for TRON accounts via a new API endpoint.

- **Tests**
  - Introduced new tests to verify the withdrawal and unfreeze amount query functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->